### PR TITLE
mint during any stage

### DIFF
--- a/src/REVBasicDeployer.sol
+++ b/src/REVBasicDeployer.sol
@@ -140,9 +140,11 @@ contract REVBasicDeployer is ERC165, ERC2771Context, IREVBasicDeployer, IJBRules
         // Keep a reference to the buyback hook.
         IJBRulesetDataHook buybackHook = buybackHookOf[context.projectId];
 
-        // // Set the values to be those returned by the buyback hook's data source.
+        // Set the values to be those returned by the buyback hook's data source.
         if (buybackHook != IJBRulesetDataHook(address(0))) {
             (weight, buybackHookSpecifications) = buybackHook.beforePayRecordedWith(context);
+        } else {
+            weight = context.weight;
         }
 
         // Check if a buyback hook is used.
@@ -384,14 +386,14 @@ contract REVBasicDeployer is ERC165, ERC2771Context, IREVBasicDeployer, IJBRules
     /// @param revnetId The ID of the revnet to mint tokens from.
     /// @param beneficiary The address to mint tokens to.
     function mintFor(uint256 revnetId, address beneficiary) external {
-        // Get a reference to the revnet's current ruleset.
-        JBRuleset memory ruleset = CONTROLLER.RULESETS().currentOf(revnetId);
+        // Get a reference to the revnet's current stage.
+        JBRuleset memory stage = CONTROLLER.RULESETS().currentOf(revnetId);
 
         // Get a reference to the amount that should be minted.
-        uint256 count = allowedMintCountOf[revnetId][ruleset.id][beneficiary];
+        uint256 count = allowedMintCountOf[revnetId][stage.id][beneficiary];
 
         // Reset the mint amount.
-        allowedMintCountOf[revnetId][ruleset.id][beneficiary] = 0;
+        allowedMintCountOf[revnetId][stage.id][beneficiary] = 0;
 
         // Premint tokens to the split operator if needed.
         if (count != 0) {
@@ -404,7 +406,7 @@ contract REVBasicDeployer is ERC165, ERC2771Context, IREVBasicDeployer, IJBRules
             });
         }
 
-        emit Mint(revnetId, ruleset.id, beneficiary, count, msg.sender);
+        emit Mint(revnetId, stage.id, beneficiary, count, msg.sender);
     }
 
     //*********************************************************************//

--- a/src/REVBasicDeployer.sol
+++ b/src/REVBasicDeployer.sol
@@ -390,6 +390,9 @@ contract REVBasicDeployer is ERC165, ERC2771Context, IREVBasicDeployer, IJBRules
         // Get a reference to the amount that should be minted.
         uint256 count = allowedMintCountOf[revnetId][ruleset.id][beneficiary];
 
+        // Reset the mint amount.
+        allowedMintCountOf[revnetId][ruleset.id][beneficiary] = 0;
+
         // Premint tokens to the split operator if needed.
         if (count != 0) {
             CONTROLLER.mintTokensOf({
@@ -400,9 +403,6 @@ contract REVBasicDeployer is ERC165, ERC2771Context, IREVBasicDeployer, IJBRules
                 useReservedRate: false
             });
         }
-
-        // Reset the mint amount.
-        allowedMintCountOf[revnetId][ruleset.id][beneficiary] = 0;
 
         emit Mint(revnetId, ruleset.id, beneficiary, count, msg.sender);
     }

--- a/src/REVBasicDeployer.sol
+++ b/src/REVBasicDeployer.sol
@@ -81,9 +81,9 @@ contract REVBasicDeployer is ERC165, ERC2771Context, IREVBasicDeployer, IJBRules
 
     /// @notice The specification of how many tokens are still allowed to be minted at each stage of a revnet.
     /// @custom:param revnetId The ID of the revnet to which the mint applies.
-    /// @custom:param rulesetId The ID of the ruleset to which the mint applies.
+    /// @custom:param stageId The ID of the ruleset to which the mint applies.
     /// @custom:param beneficiary The address that will benefit from the mint.
-    mapping(uint256 revnetId => mapping(uint256 rulesetId => mapping(address beneficiary => uint256))) public
+    mapping(uint256 revnetId => mapping(uint256 stageId => mapping(address beneficiary => uint256))) public
         allowedMintCountOf;
 
     //*********************************************************************//
@@ -644,6 +644,7 @@ contract REVBasicDeployer is ERC165, ERC2771Context, IREVBasicDeployer, IJBRules
 
                 // Store the amount of tokens that can be minted during this stage from this chain.
                 if (mintConfig.chainId == block.chainid) {
+                    // Stage IDs are indexed incrementally from the timestamp of this transaction.
                     allowedMintCountOf[revnetId][block.timestamp + i][mintConfig.beneficiary] += mintConfig.count;
                 }
             }

--- a/src/REVBasicDeployer.sol
+++ b/src/REVBasicDeployer.sol
@@ -54,8 +54,8 @@ contract REVBasicDeployer is ERC165, ERC2771Context, IREVBasicDeployer, IJBRules
     //*********************************************************************//
 
     /// @notice The amount of time from a sucker being deployed to when it can facilitate exits.
-    /// @dev 90 days.
-    uint256 public constant EXIT_DELAY = 7_776_000;
+    /// @dev 30 days.
+    uint256 public constant EXIT_DELAY = 2_592_000;
 
     //*********************************************************************//
     // --------------- public immutable stored properties ---------------- //

--- a/src/REVBasicDeployer.sol
+++ b/src/REVBasicDeployer.sol
@@ -644,7 +644,7 @@ contract REVBasicDeployer is ERC165, ERC2771Context, IREVBasicDeployer, IJBRules
 
                 // Store the amount of tokens that can be minted during this stage from this chain.
                 if (mintConfig.chainId == block.chainid) {
-                    allowedMintCountOf[revnetId][block.timestamp + i][mintConfig.beneficiary] += mintConfig.tokenAmount;
+                    allowedMintCountOf[revnetId][block.timestamp + i][mintConfig.beneficiary] += mintConfig.count;
                 }
             }
         }
@@ -795,7 +795,7 @@ contract REVBasicDeployer is ERC165, ERC2771Context, IREVBasicDeployer, IJBRules
     /// @notice mintConfig The data that defines how many tokens are allowed to be minted at a stage.
     /// @return encodedMintConfig The encoded mint config.
     function _encodedMintConfig(REVMintConfig memory mintConfig) internal pure returns (bytes memory) {
-        return abi.encode(mintConfig.chainId, mintConfig.beneficiary, mintConfig.tokenAmount);
+        return abi.encode(mintConfig.chainId, mintConfig.beneficiary, mintConfig.count);
     }
 
     /// @notice Returns the sender, prefered to use over `msg.sender`

--- a/src/REVBasicDeployer.sol
+++ b/src/REVBasicDeployer.sol
@@ -396,15 +396,15 @@ contract REVBasicDeployer is ERC165, ERC2771Context, IREVBasicDeployer, IJBRules
         allowedMintCountOf[revnetId][stage.id][beneficiary] = 0;
 
         // Premint tokens to the split operator if needed.
-        if (count != 0) {
-            CONTROLLER.mintTokensOf({
-                projectId: revnetId,
-                tokenCount: count,
-                beneficiary: beneficiary,
-                memo: "",
-                useReservedRate: false
-            });
-        }
+        if (count == 0) return;
+
+        CONTROLLER.mintTokensOf({
+            projectId: revnetId,
+            tokenCount: count,
+            beneficiary: beneficiary,
+            memo: "",
+            useReservedRate: false
+        });
 
         emit Mint(revnetId, stage.id, beneficiary, count, msg.sender);
     }

--- a/src/interfaces/IREVBasicDeployer.sol
+++ b/src/interfaces/IREVBasicDeployer.sol
@@ -33,11 +33,7 @@ interface IREVBasicDeployer {
     );
 
     event Mint(
-        uint256 indexed revnetId,
-        uint256 indexed stageId,
-        address indexed beneficiary,
-        uint256 count,
-        address caller
+        uint256 indexed revnetId, uint256 indexed stageId, address indexed beneficiary, uint256 count, address caller
     );
 
     function EXIT_DELAY() external view returns (uint256);

--- a/src/interfaces/IREVBasicDeployer.sol
+++ b/src/interfaces/IREVBasicDeployer.sol
@@ -32,6 +32,14 @@ interface IREVBasicDeployer {
         address caller
     );
 
+    event Mint(
+        uint256 indexed revnetId,
+        uint256 indexed stageId,
+        address indexed beneficiary,
+        uint256 count,
+        address caller
+    );
+
     function EXIT_DELAY() external view returns (uint256);
     function CONTROLLER() external view returns (IJBController);
     function SUCKER_REGISTRY() external view returns (IBPSuckerRegistry);

--- a/src/structs/REVConfig.sol
+++ b/src/structs/REVConfig.sol
@@ -8,6 +8,7 @@ import {REVDescription} from "./REVDescription.sol";
 /// @custom:member baseCurrency The currency that the issuance is based on.
 /// @custom:member premintTokenAmount The number of tokens that should be preminted to the initial operator.
 /// @custom:member premintChainId The ID of the chain on which the premint should be honored.
+/// @custom:member premintStage The stage during which the premint should be honored.
 /// @custom:member initialSplitOperator The address that will receive the token premint and initial production split,
 /// and who
 /// is
@@ -16,8 +17,6 @@ import {REVDescription} from "./REVDescription.sol";
 struct REVConfig {
     REVDescription description;
     uint32 baseCurrency;
-    uint256 premintTokenAmount;
-    uint256 premintChainId;
     address initialSplitOperator;
     REVStageConfig[] stageConfigurations;
 }

--- a/src/structs/REVMintConfig.sol
+++ b/src/structs/REVMintConfig.sol
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+/// @custom:member chainId The ID of the chain on which the mint should be honored.
+/// @custom:member tokenAmount The number of tokens that should be minted.
+/// @custom:member beneficiary The address that will receive the minted tokens.
+struct REVMintConfig {
+    uint256 chainId;
+    uint256 tokenAmount;
+    address beneficiary;
+}

--- a/src/structs/REVMintConfig.sol
+++ b/src/structs/REVMintConfig.sol
@@ -2,10 +2,10 @@
 pragma solidity ^0.8.0;
 
 /// @custom:member chainId The ID of the chain on which the mint should be honored.
-/// @custom:member tokenAmount The number of tokens that should be minted.
+/// @custom:member count The number of tokens that should be minted.
 /// @custom:member beneficiary The address that will receive the minted tokens.
 struct REVMintConfig {
     uint256 chainId;
-    uint256 tokenAmount;
+    uint256 count;
     address beneficiary;
 }

--- a/src/structs/REVStageConfig.sol
+++ b/src/structs/REVStageConfig.sol
@@ -1,7 +1,10 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
+import {REVMintConfig} from "./REVMintConfig.sol";
+
 /// @custom:member startsAtOrAfter The timestamp to start a stage at the given rate at or after.
+/// @custom:member mintConfigs The configurations of mints during this stage.
 /// @custom:member splitRate The percentage of newly issued tokens that should be split with the operator, out
 /// of
 /// 10_000 (JBConstants.MAX_RESERVED_RATE).
@@ -19,6 +22,7 @@ pragma solidity ^0.8.0;
 /// redemptions are made, everyone's redemptions are treated equally. The higher the intensity, the higher the tax.
 struct REVStageConfig {
     uint40 startsAtOrAfter;
+    REVMintConfig[] mintConfigs;
     uint16 splitRate;
     uint112 initialIssuanceRate;
     uint40 priceCeilingIncreaseFrequency;


### PR DESCRIPTION
# Description

Allows a revnet to specify the ability to mint during any stage, not just premint.

This allows for dynamics where Stage 1 allows for 1:1 refunds, and a "premint" is moved to Stage 2 which then dilutes the opportunity for a refund.

## Limitations & risks

*Are there any trade-off or new vulnarbility surface based on theses changes?*

# Check-list
- [ ] Tests are covering the new feature
- [ ] Code is [natspec'd](https://docs.soliditylang.org/en/v0.8.17/natspec-format.html)
- [ ] Code is [linted and formatted](https://docs.soliditylang.org/en/v0.8.17/style-guide.html)
- [ ] I have run the test locally (and they pass)
- [ ] I have rebased to the latest main commit (and tests still pass)

# Interactions
These changes will impact the following contracts:
- Directly:

- Indirectly: