### PR TITLE
refactor: added operator back to hash

### DIFF
--- a/src/interfaces/IREVDeployer.sol
+++ b/src/interfaces/IREVDeployer.sol
@@ -25,7 +25,7 @@ interface IREVDeployer {
     event DeploySuckers(
         uint256 indexed revnetId,
         bytes32 indexed salt,
-        bytes encodedConfiguration,
+        bytes32 encodedConfigurationHash,
         REVSuckerDeploymentConfig suckerDeploymentConfiguration,
         address caller
     );
@@ -77,7 +77,6 @@ interface IREVDeployer {
     function cashOutDelayOf(uint256 revnetId) external view returns (uint256);
     function deploySuckersFor(
         uint256 revnetId,
-        bytes calldata encodedConfiguration,
         REVSuckerDeploymentConfig calldata suckerDeploymentConfiguration
     )
         external

--- a/test/REV.integrations.t.sol
+++ b/test/REV.integrations.t.sol
@@ -304,7 +304,7 @@ contract REVnet_Integrations is TestBaseWorkflow, JBTest {
         // which wil call the balanceOf to check its own balance.
         vm.mockCall(address(token), abi.encodeWithSelector(IERC20.balanceOf.selector), abi.encode(0));
 
-        address[] memory suckers = REV_DEPLOYER.deploySuckersFor(REVNET_ID, ENCODED_CONFIG, revConfig);
+        address[] memory suckers = REV_DEPLOYER.deploySuckersFor(REVNET_ID, revConfig);
 
         // Ensure it's registered
         bool isSucker = SUCKER_REGISTRY.isSuckerOf(REVNET_ID, suckers[0]);


### PR DESCRIPTION
…`encodedConfigurationHash`

# Description

*What does this PR: do, how, why?*

## Limitations & risks

*Are there any trade-off or new vulnarbility surface based on theses changes?*

# Check-list
- [ ] Tests are covering the new feature
- [ ] Code is [natspec'd](https://docs.soliditylang.org/en/v0.8.17/natspec-format.html)
- [ ] Code is [linted and formatted](https://docs.soliditylang.org/en/v0.8.17/style-guide.html)
- [ ] I have run the test locally (and they pass)
- [ ] I have rebased to the latest main commit (and tests still pass)

# Interactions
These changes will impact the following contracts:
- Directly:

- Indirectly: