### PR TITLE
fix: permission index offset in `_extraOperatorPermissions(..)`

### DIFF
--- a/src/REVDeployer.sol
+++ b/src/REVDeployer.sol
@@ -538,7 +538,7 @@ contract REVDeployer is ERC2771Context, IREVDeployer, IJBRulesetDataHook, IJBCas
 
         // Copy the custom permissions into the array.
         for (uint256 i; i < customSplitOperatorPermissionIndexes.length; i++) {
-            allOperatorPermissions[3 + i] = customSplitOperatorPermissionIndexes[i];
+            allOperatorPermissions[4 + i] = customSplitOperatorPermissionIndexes[i];
         }
     }
 


### PR DESCRIPTION
# Description

*What does this PR: do, how, why?*

## Limitations & risks

*Are there any trade-off or new vulnarbility surface based on theses changes?*

# Check-list
- [ ] Tests are covering the new feature
- [ ] Code is [natspec'd](https://docs.soliditylang.org/en/v0.8.17/natspec-format.html)
- [ ] Code is [linted and formatted](https://docs.soliditylang.org/en/v0.8.17/style-guide.html)
- [ ] I have run the test locally (and they pass)
- [ ] I have rebased to the latest main commit (and tests still pass)

# Interactions
These changes will impact the following contracts:
- Directly:

- Indirectly: